### PR TITLE
[fix] video削除時にvideoFileが消えない

### DIFF
--- a/backend-graphql/app/graphql/mutations/delete_video.rb
+++ b/backend-graphql/app/graphql/mutations/delete_video.rb
@@ -5,7 +5,7 @@ module Mutations
     argument :id, ID, required: true
 
     def resolve(id:)
-      Video.find(id).delete
+      Video.find(id).destroy
       { id: id }
     end
   end


### PR DESCRIPTION
- videoレコード削除時に、videofileレコードが消えないのを修正
  - `delete`はSQL直接叩いて削除
  - `destroy`はActiveRecord経由して削除 